### PR TITLE
Universal link

### DIFF
--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -43,7 +43,7 @@ module.exports = class IrmaCore {
         break;
       case 'MediumContemplation':
         if ( this._options.userAgent == 'Android' || this._options.userAgent == 'iOS' )
-          this._stateMachine.transition('showIrmaButton', `https://irma.app/-/session#${encodeURIComponent(JSON.stringify(payload))}`);
+          this._stateMachine.transition('showIrmaButton', payload);
         else
           this._stateMachine.transition('showQRCode', payload);
         break;

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -43,7 +43,7 @@ module.exports = class IrmaCore {
         break;
       case 'MediumContemplation':
         if ( this._options.userAgent === 'Android' || this._options.userAgent === 'iOS' )
-          this._stateMachine.transition('showIrmaButton', payload);
+          this._stateMachine.transition('showIrmaButton', `https://irma.app/-/session#${encodeURIComponent(JSON.stringify(payload))}`);
         else
           this._stateMachine.transition('showQRCode', payload);
         break;

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -42,7 +42,7 @@ module.exports = class IrmaCore {
         if ( this._reject ) this._reject(payload);
         break;
       case 'MediumContemplation':
-        if ( this._options.userAgent === 'Android' || this._options.userAgent === 'iOS' )
+        if ( this._options.userAgent == 'Android' || this._options.userAgent == 'iOS' )
           this._stateMachine.transition('showIrmaButton', `https://irma.app/-/session#${encodeURIComponent(JSON.stringify(payload))}`);
         else
           this._stateMachine.transition('showQRCode', payload);

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -6,11 +6,7 @@ module.exports = class IrmaCore {
   constructor(options) {
     this._modules = [];
     this._options = options || {};
-    const agent = userAgent();
-    const storedSession = localStorage.getItem('irmajs-options');
-    if (agent !== 'nodejs' && storedSession)
-      this._options = JSON.parse(storedSession);
-    this._options.userAgent = agent;
+    this._options.userAgent = userAgent();
 
     this._stateMachine = new StateMachine(this._options.debugging);
     this._stateMachine.addStateChangeListener((s) => this._stateChangeListener(s));
@@ -41,26 +37,15 @@ module.exports = class IrmaCore {
     switch(newState) {
       case 'Success':
         if ( this._resolve ) this._resolve(payload);
-        if (this._options.userAgent !== 'nodejs')
-          localStorage.removeItem('irmajs-options');
         break;
       case 'BrowserNotSupported':
         if ( this._reject ) this._reject(payload);
         break;
       case 'MediumContemplation':
-        if (this._options.userAgent !== 'nodejs')
-          localStorage.setItem('irmajs-options', JSON.stringify(this._options));
         if ( this._options.userAgent === 'Android' || this._options.userAgent === 'iOS' )
           this._stateMachine.transition('showIrmaButton', payload);
         else
           this._stateMachine.transition('showQRCode', payload);
-        break;
-      case 'Cancelled':
-      case 'TimedOut':
-      case 'Error':
-        if (this._options.userAgent !== 'nodejs')
-          localStorage.removeItem('irmajs-options');
-        this._options.sessionPtr = null; // sessionPtr generated error, so make sure it gets not started again
         break;
     }
   }

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -5,7 +5,7 @@ module.exports = class IrmaCore {
 
   constructor(options) {
     this._modules = [];
-    this._options = options || {};
+    this._options = JSON.parse(localStorage.getItem('irmajs-options')) || options || {};
     this._options.userAgent = userAgent();
 
     this._stateMachine = new StateMachine(this._options.debugging);
@@ -37,35 +37,24 @@ module.exports = class IrmaCore {
     switch(newState) {
       case 'Success':
         if ( this._resolve ) this._resolve(payload);
+        localStorage.removeItem('irmajs-options');
         break;
       case 'BrowserNotSupported':
         if ( this._reject ) this._reject(payload);
         break;
-      case 'ContinueInIrmaApp':
-        if ( payload )
-          return this._openIrmaApp(payload);
-        if ( this._options.debugging )
-          console.error("Tried to go to IRMA app without a payload");
-        break;
       case 'MediumContemplation':
-        if ( this._options.userAgent == 'Android' || this._options.userAgent == 'iOS' )
+        localStorage.setItem('irmajs-options', JSON.stringify(this._options));
+        if ( this._options.userAgent === 'Android' || this._options.userAgent === 'iOS' )
           this._stateMachine.transition('showIrmaButton', payload);
         else
           this._stateMachine.transition('showQRCode', payload);
         break;
-    }
-  }
-
-  _openIrmaApp(payload) {
-    const url = 'qr/json/' + encodeURIComponent(JSON.stringify(payload));
-
-    switch(this._options.userAgent) {
-      case 'Android':
-        if ( this._options.debugging ) console.log("📱 Opening IRMA app on Android");
-        return window.location.href = `intent://${url}#Intent;package=org.irmacard.cardemu;scheme=cardemu;l.timestamp=${Date.now()};S.browser_fallback_url=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.irmacard.cardemu;end`;
-      case 'iOS':
-        if ( this._options.debugging ) console.log("📱 Opening IRMA app on iOS");
-        return window.location.href = 'irma://' + url;
+      case 'Cancelled':
+      case 'TimedOut':
+      case 'Error':
+        localStorage.removeItem('irmajs-options');
+        this._options.sessionPtr = null; // sessionPtr generated error, so make sure it gets not started again
+        break;
     }
   }
 

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -20,10 +20,11 @@ module.exports = class StateMachine {
       console.debug(`🎰 State change: '${oldState}' → '${this._state}' (because of '${transition}')`);
 
     this._listeners.forEach(func => func({
-      newState:   this._state,
-      oldState:   oldState,
-      transition: transition,
-      payload:    payload
+      newState:      this._state,
+      oldState:      oldState,
+      transition:    transition,
+      payload:       payload,
+      universalLink: payload ? 'https://irma.app/-/session#' + encodeURIComponent(JSON.stringify(payload)) : null,
     }));
   }
 

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -20,10 +20,10 @@ module.exports = class StateMachine {
       console.debug(`🎰 State change: '${oldState}' → '${this._state}' (because of '${transition}')`);
 
     this._listeners.forEach(func => func({
-      newState:      this._state,
-      oldState:      oldState,
-      transition:    transition,
-      payload:       payload
+      newState:   this._state,
+      oldState:   oldState,
+      transition: transition,
+      payload:    payload
     }));
   }
 

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -23,8 +23,7 @@ module.exports = class StateMachine {
       newState:      this._state,
       oldState:      oldState,
       transition:    transition,
-      payload:       payload,
-      universalLink: payload ? 'https://irma.app/-/session#' + encodeURIComponent(JSON.stringify(payload)) : null,
+      payload:       payload
     }));
   }
 

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -46,9 +46,9 @@ module.exports = {
     appConnected:   'ContinueInIrmaApp',
     fail:           'Error',
 
-    succeed:        'Success',     // Because we sometimes miss the appConnected
-    cancel:         'Cancelled',   // transition on iOS, but these's no need to
-    timeout:        'TimedOut'     // go to the Error state in those cases.
+    succeed:        'Success',   // We sometimes miss the appConnected transition
+    cancel:         'Cancelled', // on iOS, that's why these transitions are here
+    timeout:        'TimedOut'   // too. So we don't 'fail' to the Error state.
   },
 
   ShowingQRCodeInstead: {

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   ShowingQRCode: {
-    codeScanned:    'ContinueOn2ndDevice',
+    appConnected:   'ContinueOn2ndDevice',
     timeout:        'TimedOut',
     fail:           'Error'
   },
@@ -43,12 +43,12 @@ module.exports = {
 
   ShowingIrmaButton: {
     chooseQR:       'ShowingQRCodeInstead',
-    codeScanned:    'ContinueInIrmaApp',
+    appConnected:   'ContinueInIrmaApp',
     fail:           'Error'
   },
 
   ShowingQRCodeInstead: {
-    codeScanned:    'ContinueOn2ndDevice',
+    appConnected:   'ContinueOn2ndDevice',
     restart:        'Loading',
     timeout:        'TimedOut',
     fail:           'Error'

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -44,7 +44,11 @@ module.exports = {
   ShowingIrmaButton: {
     chooseQR:       'ShowingQRCodeInstead',
     appConnected:   'ContinueInIrmaApp',
-    fail:           'Error'
+    fail:           'Error',
+
+    succeed:        'Success',     // Because we sometimes miss the appConnected
+    cancel:         'Cancelled',   // transition on iOS, but these's no need to
+    timeout:        'TimedOut'     // go to the Error state in those cases.
   },
 
   ShowingQRCodeInstead: {

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -43,7 +43,7 @@ module.exports = {
 
   ShowingIrmaButton: {
     chooseQR:       'ShowingQRCodeInstead',
-    openIrmaApp:    'ContinueInIrmaApp',
+    codeScanned:    'ContinueInIrmaApp',
     fail:           'Error'
   },
 

--- a/plugins/irma-dummy/index.js
+++ b/plugins/irma-dummy/index.js
@@ -48,7 +48,7 @@ module.exports = class IrmaDummy {
         case 'timeout':
           return this._stateMachine.transition('timeout');
         default:
-          return this._stateMachine.transition('codeScanned');
+          return this._stateMachine.transition('appConnected');
       }
     }, this._options.timing.scan);
   }

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -48,7 +48,7 @@ module.exports = class IrmaServer {
   }
 
   _serverStateChange(newState) {
-    if ( newState == 'CONNECTED' )
+    if ( newState === 'CONNECTED' )
       return this._stateMachine.transition('codeScanned');
 
     // All other states lead to a full session reload, so stop listening

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -48,7 +48,7 @@ module.exports = class IrmaServer {
   }
 
   _serverStateChange(newState) {
-    if ( newState === 'CONNECTED' )
+    if ( newState == 'CONNECTED' )
       return this._stateMachine.transition('codeScanned');
 
     // All other states lead to a full session reload, so stop listening

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -49,7 +49,7 @@ module.exports = class IrmaServer {
 
   _serverStateChange(newState) {
     if ( newState == 'CONNECTED' )
-      return this._stateMachine.transition('codeScanned');
+      return this._stateMachine.transition('appConnected');
 
     // All other states lead to a full session reload, so stop listening
     this._serverState.close();

--- a/plugins/irma-web/dom-manipulations.js
+++ b/plugins/irma-web/dom-manipulations.js
@@ -109,7 +109,7 @@ module.exports = class DOMManipulations {
   _stateShowingIrmaButton() {
     return `
       <!-- State: ShowingButton -->
-      <a id="irma-web-button-link" data-irma-glue-transition="openIrmaApp">
+      <a id="irma-web-button-link">
         <button class="irma-web-button">${this._translations.button}</button>
       </a>
       <p><a data-irma-glue-transition="chooseQR">${this._translations.qrCode}</a></p>

--- a/plugins/irma-web/dom-manipulations.js
+++ b/plugins/irma-web/dom-manipulations.js
@@ -109,7 +109,9 @@ module.exports = class DOMManipulations {
   _stateShowingIrmaButton() {
     return `
       <!-- State: ShowingButton -->
-      <button class="irma-web-button" data-irma-glue-transition="openIrmaApp">${this._translations.button}</button>
+      <a id="irma-web-button-link" data-irma-glue-transition="openIrmaApp">
+        <button class="irma-web-button">${this._translations.button}</button>
+      </a>
       <p><a data-irma-glue-transition="chooseQR">${this._translations.qrCode}</a></p>
     `;
   }

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -16,19 +16,22 @@ module.exports = class IrmaWeb {
     );
   }
 
-  stateChange({newState, payload}) {
+  stateChange({newState, payload, universalLink}) {
     this._lastPayload = payload;
     switch(newState) {
       case 'ContinueInIrmaApp':
-        return window.setTimeout(() => this._dom.renderState(newState), 200);
+        return this._dom.renderState(newState);
       case 'ShowingQRCode':
       case 'ShowingQRCodeInstead':
-        this._dom.renderState(newState)
+        this._dom.renderState(newState);
         return QRCode.toCanvas(
           document.getElementById('irma-web-qr-canvas'),
           JSON.stringify(payload),
           {width: '230', margin: '1'}
         );
+      case 'ShowingIrmaButton':
+        this._dom.renderState(newState);
+        return document.getElementById('irma-web-button-link').setAttribute('href', universalLink);
       default:
         this._dom.renderState(newState)
     }

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -19,19 +19,22 @@ module.exports = class IrmaWeb {
   stateChange({newState, payload}) {
     this._lastPayload = payload;
     switch(newState) {
-      case 'ContinueInIrmaApp':
-        return this._dom.renderState(newState);
       case 'ShowingQRCode':
       case 'ShowingQRCodeInstead':
         this._dom.renderState(newState);
-        return QRCode.toCanvas(
+        QRCode.toCanvas(
           document.getElementById('irma-web-qr-canvas'),
           JSON.stringify(payload),
           {width: '230', margin: '1'}
         );
+        break;
+
       case 'ShowingIrmaButton':
         this._dom.renderState(newState);
-        return document.getElementById('irma-web-button-link').setAttribute('href', payload);
+        document.getElementById('irma-web-button-link')
+                .setAttribute('href', payload);
+        break;
+
       default:
         this._dom.renderState(newState)
     }

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -16,7 +16,7 @@ module.exports = class IrmaWeb {
     );
   }
 
-  stateChange({newState, payload, universalLink}) {
+  stateChange({newState, payload}) {
     this._lastPayload = payload;
     switch(newState) {
       case 'ContinueInIrmaApp':
@@ -31,7 +31,7 @@ module.exports = class IrmaWeb {
         );
       case 'ShowingIrmaButton':
         this._dom.renderState(newState);
-        return document.getElementById('irma-web-button-link').setAttribute('href', universalLink);
+        return document.getElementById('irma-web-button-link').setAttribute('href', payload);
       default:
         this._dom.renderState(newState)
     }

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -36,7 +36,7 @@ module.exports = class IrmaWeb {
         break;
 
       default:
-        this._dom.renderState(newState)
+        this._dom.renderState(newState);
     }
   }
 

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -32,7 +32,7 @@ module.exports = class IrmaWeb {
       case 'ShowingIrmaButton':
         this._dom.renderState(newState);
         document.getElementById('irma-web-button-link')
-                .setAttribute('href', payload);
+                .setAttribute('href', `https://irma.app/-/session#${encodeURIComponent(JSON.stringify(payload))}`);
         break;
 
       default:


### PR DESCRIPTION
This pull request implements the universal links. For now I deleted the localStorage support for sessions that have a returnURL. I think support for this is necessary eventually for iOS devices, but doing this via localStorage is maybe not the right way. There are too much corner cases.

Eventually it is maybe better to add the sessionPtr (and maybe the token if present) as URL parameter in the returnURL such that `irmajs` knows for sure the actual returning flow is used. Then there are no problems when a session is aborted without deleting the localStorage.